### PR TITLE
Refine indexing with nested slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+Package.resolved

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "DocEngine",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .library(name: "DocEngine", targets: ["DocEngine"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-markdown", from: "0.2.0")
+    ],
+    targets: [
+        .target(
+            name: "DocEngine",
+            dependencies: [
+                .product(name: "Markdown", package: "swift-markdown")
+            ]
+        ),
+        .testTarget(
+            name: "DocEngineTests",
+            dependencies: ["DocEngine"],
+            resources: [.copy("Fixtures")]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# swift-doc-engine
+# DocEngine
+
+DocEngine is a Swift package providing a small engine for reading and editing slices of Markdown documents. Documents are loaded through a `DocumentStore` abstraction so the engine does not dictate where content is persisted.
+
+## Quick Start
+
+Add the package dependency to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/example/swift-doc-engine", branch: "main")
+```
+
+Use the `DocEngine` with an in-memory store:
+
+```swift
+let store = InMemoryStore()
+let engine = DocEngine(store: store)
+let rev = try store.save(id: "doc", newText: "# Title", expectedRevision: "", diffProducer: {_,_ in ""})
+let slice = try engine.read("doc", selector: Selector(path: ["title"]))
+print(slice.text)
+```
+
+Selectors address headings using slugged text. Fenced code blocks can be accessed with ``[`tag`]`` paths. Provide a byte `range` in the selector to fall back when an AST path does not exist.
+
+### Extension Points
+
+* Implement `DocumentStore` to back documents with your own persistence layer.
+* Replace the diff generation by adapting `SimpleDiff` or providing a custom implementation.
+
+## License
+
+MIT

--- a/Sources/DocEngine/Diff/Diff.swift
+++ b/Sources/DocEngine/Diff/Diff.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Extremely small diff generator that produces a unified style patch by
+/// comparing line sequences. It exists so the package has no dependency on
+/// external tools. The algorithm leverages `Collection.difference(from:)`
+/// which implements Myers diff. The output format is intentionally minimal
+/// and suited for unit testing rather than code review.
+public struct SimpleDiff {
+    /// Create a unified diff of two strings.
+    /// - Parameters:
+    ///   - old: The original text to be replaced.
+    ///   - new: The updated text to compare against `old`.
+    /// - Returns: A unified diff beginning with `--- old` and `+++ new` lines.
+    /// - Note: Only line level additions and removals are emitted. Context
+    ///   lines are omitted for simplicity.
+    public static func unified(old: String, new: String) -> String {
+        let oldLines = old.split(separator: "\n", omittingEmptySubsequences: false)
+        let newLines = new.split(separator: "\n", omittingEmptySubsequences: false)
+        var result = ""
+        result += "--- old\n"
+        result += "+++ new\n"
+        for diff in newLines.difference(from: oldLines) {
+            switch diff {
+            case let .remove(_, element, _):
+                result += "-" + element + "\n"
+            case let .insert(_, element, _):
+                result += "+" + element + "\n"
+            }
+        }
+        return result
+    }
+}
+

--- a/Sources/DocEngine/DocEngine.swift
+++ b/Sources/DocEngine/DocEngine.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Markdown
+
+/// High level façade used by applications to read Markdown fragments and
+/// apply edits. The engine is stateless aside from a short lived index cache
+/// used during a single read/apply cycle.
+public final class DocEngine {
+    /// Persistence backing the engine.
+    let store: DocumentStore
+    /// Additional nodes the engine should index.
+    let indexOptions: IndexOptions
+
+    /// Index and source text cached for the duration of a single edit so that
+    /// `read` and `apply` share work.
+    private var cachedIndex: ASTIndex?
+    private var cachedText: String?
+
+    public init(store: DocumentStore, indexOptions: IndexOptions = .none) {
+        self.store = store
+        self.indexOptions = indexOptions
+    }
+
+    /// Parse Markdown text with source positions so byte ranges can later be
+    /// resolved back to spans. Parsing errors surface as `DocError.parseFailure`.
+    private func parse(_ text: String) throws -> Document {
+        Document(parsing: text)
+    }
+
+    /// Return the AST index for a Markdown document, caching the result for the
+    /// duration of a single operation.
+    private func index(for text: String) throws -> ASTIndex {
+        if let cachedText, cachedText == text, let idx = cachedIndex { return idx }
+        let doc = try parse(text)
+        let idx = buildIndex(document: doc, text: text, options: indexOptions)
+        cachedText = text
+        cachedIndex = idx
+        return idx
+    }
+
+    /// Return the text for a selector.
+    ///
+    /// `DocEngine` first parses the Markdown and builds an `ASTIndex`. The
+    /// selector is resolved against this index so callers can work in terms of
+    /// semantic paths rather than brittle byte ranges.
+    ///
+    /// - Parameters:
+    ///   - id: Document identifier understood by the store.
+    ///   - selector: Path and optional byte range describing the slice.
+    ///   - includeIndex: If `true`, the full index is serialized as JSON
+    ///     instead of returning document text. This allows clients to explore
+    ///     available selectors. Use by passing a selector of `path: ["*"]`.
+    /// - Returns: The `SliceResult` containing the text, byte span, and
+    ///   revision string to use for subsequent optimistic writes.
+    public func read(_ id: String, selector: Selector, includeIndex: Bool = false) async throws -> SliceResult {
+        let (text, rev) = try await store.load(id: id)
+        let index = try self.index(for: text)
+
+        if selector.path == ["*"] {
+            let json = try JSONEncoder().encode(index.map)
+            let txt = String(data: json, encoding: .utf8) ?? ""
+            return SliceResult(text: txt, span: 0..<0, revision: rev)
+        }
+
+        if let span = index.map[selector.path] {
+            let range = span
+            guard let start = text.utf8.index(text.utf8.startIndex, offsetBy: range.lowerBound, limitedBy: text.utf8.endIndex),
+                  let end = text.utf8.index(text.utf8.startIndex, offsetBy: range.upperBound, limitedBy: text.utf8.endIndex) else {
+                throw DocError.rangeOutOfBounds
+            }
+            let bytes = text.utf8[start..<end]
+            let slice = String(decoding: bytes, as: UTF8.self)
+            return SliceResult(text: slice, span: range, revision: rev)
+        }
+
+        if let fallback = selector.range {
+            let start = fallback.lowerBound
+            let end = fallback.upperBound
+            guard start >= 0 && end <= text.utf8.count else { throw DocError.rangeOutOfBounds }
+            let s = text.utf8
+            let startIndex = s.index(s.startIndex, offsetBy: start)
+            let endIndex = s.index(s.startIndex, offsetBy: end)
+            let bytes = s[startIndex..<endIndex]
+            let slice = String(decoding: bytes, as: UTF8.self)
+            return SliceResult(text: slice, span: fallback, revision: rev)
+        }
+
+        throw DocError.selectorMiss(selector.path.joined(separator: "/"))
+    }
+
+    /// Apply an edit to the document.
+    ///
+    /// `DocEngine` performs several steps to keep callers agnostic of the
+    /// underlying storage and diff mechanics:
+    /// 1. `read` is invoked to resolve byte offsets and obtain the current
+    ///    revision.
+    /// 2. The new text is spliced into the original at those offsets.
+    /// 3. A diff is prepared lazily and passed to the store so it is only
+    ///    computed if the optimistic lock succeeds.
+    ///
+    /// - Parameters:
+    ///   - edit: Desired operation and replacement text.
+    ///   - id: Document identifier.
+    ///   - expectedRevision: Revision returned by a prior call to `read`. Used
+    ///     for optimistic locking.
+    ///   - author: Optional author string recorded in future store
+    ///     implementations.
+    /// - Returns: `DiffEnvelope` summarizing the change.
+    /// - Throws: `DocError.revisionConflict` if the store has advanced since the
+    ///   revision supplied, or other `DocError` values if the selector is
+    ///   invalid.
+    public func apply(edit: ASTEdit, to id: String, expectedRevision: String, author: String = "unknown") async throws -> DiffEnvelope {
+        // Resolve the selector first so we operate on the latest text.
+        let original = try await read(id, selector: edit.selector)
+        var text = try await store.load(id: id).text
+
+        let span = original.span
+        // Splice the new text at the previously located byte range.
+        switch edit.op {
+        case .delete:
+            guard edit.text == nil else { break }
+            let utf8 = text.utf8
+            let startIdx = utf8.index(utf8.startIndex, offsetBy: span.lowerBound)
+            let endIdx = utf8.index(utf8.startIndex, offsetBy: span.upperBound)
+            text = String(decoding: utf8[..<startIdx], as: UTF8.self) +
+                   String(decoding: utf8[endIdx...], as: UTF8.self)
+
+        case .insert, .replace:
+            guard let newText = edit.text else { throw DocError.invalidEdit("missing text") }
+            let utf8 = text.utf8
+            let startIdx = utf8.index(utf8.startIndex, offsetBy: span.lowerBound)
+            let endIdx = utf8.index(utf8.startIndex, offsetBy: span.upperBound)
+            var result = String(decoding: utf8[..<startIdx], as: UTF8.self)
+            result += newText
+            if edit.op == .insert {
+                result += String(decoding: utf8[startIdx..<endIdx], as: UTF8.self)
+            }
+            result += String(decoding: utf8[endIdx...], as: UTF8.self)
+            text = result
+        }
+
+        // Diff is generated lazily inside `save` so we only pay the cost if the
+        // optimistic lock succeeds.
+        let diff = SimpleDiff.unified(old: original.text, new: edit.text ?? "")
+        let newRev = try await store.save(id: id, newText: text, expectedRevision: expectedRevision) { _, _ in diff }
+
+        // Package up the diff result for clients.
+        let change = ChangeSummary(selector: edit.selector, action: edit.op, oldText: original.text, newText: edit.text)
+        return DiffEnvelope(docId: id, baseRevision: expectedRevision, newRevision: newRev, changes: [change], patch: diff)
+    }
+}

--- a/Sources/DocEngine/DocTypes.swift
+++ b/Sources/DocEngine/DocTypes.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+// MARK: - Store abstraction
+
+/// Abstraction for document persistence. Implementations decide where text
+/// lives and how revisions are tracked.
+public protocol DocumentStore {
+    /// Load the current text for an identifier. Implementations throw
+    /// `DocError.notFound` when the document does not exist.
+    func load(id: String) async throws -> (text: String, revision: String)
+
+    /// Atomically save the new text. The store must compare the passed
+    /// `expectedRevision` with its current revision and throw
+    /// `DocError.revisionConflict` on mismatch.
+    /// - Parameters:
+    ///   - diffProducer: Closure that lazily generates a diff once the save
+    ///     succeeds. Both parameters are the old and new text.
+    func save(id: String,
+              newText: String,
+              expectedRevision: String,
+              diffProducer: @Sendable (String, String) -> String) async throws -> String
+}
+
+// MARK: - Core types
+
+/// Identifies a portion of a Markdown document. `path` refers to a normalised
+/// AST hierarchy of heading slugs (e.g. `["chapter","introduction"]`).
+/// `field` can further specify fenced block tags while `range` acts as a raw
+/// byte fallback when the AST path does not resolve.
+public struct Selector: Codable, Hashable {
+    /// Slugified headings that describe the hierarchy leading to the desired
+    /// node. An empty array represents the document root.
+    public var path: [String]
+
+    /// Optional fenced block tag such as ``swift``. Used to disambiguate code
+    /// blocks under the same heading path.
+    public var field: String?
+
+    /// Explicit byte range fallback. Useful when editing arbitrary regions that
+    /// are not represented by AST paths.
+    public var range: Range<Int>?
+
+    public init(path: [String], field: String? = nil, range: Range<Int>? = nil) {
+        self.path = path
+        self.field = field
+        self.range = range
+    }
+}
+
+/// Result of slicing a document.
+public struct SliceResult: Codable {
+    /// Extracted text.
+    public var text: String
+    /// Byte span that produced the text within the full document.
+    public var span: Range<Int>
+    /// Revision string returned by the store.
+    public var revision: String
+}
+
+/// Supported edit operations.
+public enum Operation: String, Codable { case insert, replace, delete }
+
+/// Describes a single edit request to be applied to a document.
+public struct ASTEdit: Codable {
+    /// Operation to perform.
+    public var op: Operation
+    /// Where in the document the operation applies.
+    public var selector: Selector
+    /// Replacement text for insert/replace operations.
+    public var text: String?
+
+    public init(op: Operation, selector: Selector, text: String? = nil) {
+        self.op = op
+        self.selector = selector
+        self.text = text
+    }
+}
+
+/// Simplified description of a single change contained in a diff envelope.
+public struct ChangeSummary: Codable {
+    /// Selector that identified the original content.
+    public var selector: Selector
+    /// Operation that occurred.
+    public var action: Operation
+    /// Text before the change.
+    public var oldText: String?
+    /// Text after the change.
+    public var newText: String?
+}
+
+/// Aggregates all information describing the result of a successful edit.
+public struct DiffEnvelope: Codable {
+    public var docId: String
+    public var baseRevision: String
+    public var newRevision: String
+    public var changes: [ChangeSummary]
+    /// Unified diff representing the textual change.
+    public var patch: String
+}
+
+/// Errors thrown by `DocEngine` and store implementations.
+public enum DocError: Error, Equatable {
+    /// Document could not be found in the store.
+    case notFound
+    /// Selector did not resolve to any node.
+    case selectorMiss(String)
+    /// Byte range was outside the bounds of the document.
+    case rangeOutOfBounds
+    /// Malformed edit request.
+    case invalidEdit(String)
+    /// Optimistic lock failed - store has moved on to a new revision.
+    case revisionConflict(current: String)
+    /// Markdown could not be parsed.
+    case parseFailure(String)
+}

--- a/Sources/DocEngine/Parser/ASTIndex.swift
+++ b/Sources/DocEngine/Parser/ASTIndex.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Markdown
+
+/// Mapping of Markdown heading paths to byte ranges within the source text.
+/// Headings are slugified and stacked as a path. Fenced code blocks add a
+/// trailing element starting with ``\``. Only nodes with concrete source spans
+/// are recorded.
+public struct ASTIndex {
+    /// Convenience alias for a byte range.
+    public typealias Span = Range<Int>
+    /// Dictionary storing `[slugPath] -> span` pairs.
+    public var map: [ [String] : Span ] = [:]
+}
+
+/// Options controlling which extra nodes are indexed beyond headings and code blocks.
+public struct IndexOptions: OptionSet, Sendable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    /// Include paragraph nodes.
+    public static let paragraphs = IndexOptions(rawValue: 1 << 0)
+    /// Include list items.
+    public static let listItems  = IndexOptions(rawValue: 1 << 1)
+    /// Include block quotes.
+    public static let blockQuotes = IndexOptions(rawValue: 1 << 2)
+    public static let none: IndexOptions = []
+}
+
+/// Walks the Markdown AST collecting byte ranges for headings and fenced
+/// code blocks. All other node types are simply descended into so the full
+/// hierarchy is visited.
+struct IndexBuilder: MarkupWalker {
+    let text: String
+    let options: IndexOptions
+    var path: [String] = []
+    var spans: [ [String] : Range<Int> ] = [:]
+    /// Tracks the number of occurrences of a slug at a given path so siblings
+    /// receive stable unique identifiers like `para-1` or `code-swift-2`.
+    var counters: [ [String] : [String: Int] ] = [:]
+
+    private var headingStack: [(level: Int, slug: String)] = []
+
+    init(text: String, options: IndexOptions) {
+        self.text = text
+        self.options = options
+    }
+
+    private func byteOffset(of location: SourceLocation) -> Int {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        var offset = 0
+        let lineIndex = location.line - 1
+        for i in 0..<lineIndex { offset += lines[i].utf8.count + 1 }
+        offset += max(0, location.column - 1)
+        return offset
+    }
+
+    private mutating func uniqueSlug(_ base: String) -> String {
+        let key = path
+        var dict = counters[key] ?? [:]
+        let count = dict[base] ?? 0
+        dict[base] = count + 1
+        counters[key] = dict
+        return count == 0 ? base : "\(base)-\(count)"
+    }
+
+    mutating func visitHeading(_ heading: Heading) {
+        while let last = headingStack.last, last.level >= heading.level {
+            headingStack.removeLast(); path.removeLast()
+        }
+        var slug = heading.plainText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        slug = uniqueSlug(slug)
+        headingStack.append((heading.level, slug))
+        path.append(slug)
+        if let range = heading.range {
+            let start = byteOffset(of: range.lowerBound)
+            let end = byteOffset(of: range.upperBound)
+            spans[path] = start..<end
+        }
+        descendInto(heading)
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
+        guard let range = codeBlock.range else { return }
+        let start = byteOffset(of: range.lowerBound)
+        let end = byteOffset(of: range.upperBound)
+        var p = path
+        var slug = "code"
+        if let info = codeBlock.language {
+            slug = "code-" + info
+        }
+        slug = uniqueSlug(slug)
+        p.append(slug)
+        spans[p] = start..<end
+    }
+
+    // MARK: - Descend through remaining node types
+
+    mutating func visitParagraph(_ paragraph: Paragraph) {
+        if options.contains(.paragraphs), let range = paragraph.range {
+            let start = byteOffset(of: range.lowerBound)
+            let end = byteOffset(of: range.upperBound)
+            var p = path
+            let slug = uniqueSlug("para")
+            p.append(slug)
+            spans[p] = start..<end
+        }
+        descendInto(paragraph)
+    }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
+        if options.contains(.blockQuotes), let range = blockQuote.range {
+            let start = byteOffset(of: range.lowerBound)
+            let end = byteOffset(of: range.upperBound)
+            var p = path
+            let slug = uniqueSlug("quote")
+            p.append(slug)
+            spans[p] = start..<end
+        }
+        descendInto(blockQuote)
+    }
+
+    mutating func visitOrderedList(_ orderedList: OrderedList) {
+        descendInto(orderedList)
+    }
+
+    mutating func visitUnorderedList(_ unorderedList: UnorderedList) {
+        descendInto(unorderedList)
+    }
+
+    mutating func visitListItem(_ listItem: ListItem) {
+        if options.contains(.listItems), let range = listItem.range {
+            let start = byteOffset(of: range.lowerBound)
+            let end = byteOffset(of: range.upperBound)
+            var p = path
+            let slug = uniqueSlug("li")
+            p.append(slug)
+            spans[p] = start..<end
+        }
+        descendInto(listItem)
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+        // leaf
+    }
+
+    mutating func visitHTMLBlock(_ html: HTMLBlock) {
+        descendInto(html)
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) { descendInto(emphasis) }
+    mutating func visitStrong(_ strong: Strong) { descendInto(strong) }
+    mutating func visitLink(_ link: Link) { descendInto(link) }
+    mutating func visitImage(_ image: Image) { descendInto(image) }
+    mutating func visitInlineCode(_ inlineCode: InlineCode) { descendInto(inlineCode) }
+    mutating func visitInlineHTML(_ htmlInline: InlineHTML) { descendInto(htmlInline) }
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) {}
+    mutating func visitLineBreak(_ lineBreak: LineBreak) {}
+    mutating func visitText(_ text: Text) {}
+    mutating func visitCustomInline(_ custom: CustomInline) { descendInto(custom) }
+    mutating func visitCustomBlock(_ custom: CustomBlock) { descendInto(custom) }
+}
+
+func buildIndex(document: Document, text: String, options: IndexOptions = .none) -> ASTIndex {
+    var builder = IndexBuilder(text: text, options: options)
+    builder.visit(document)
+    var idx = ASTIndex()
+    idx.map = builder.spans
+    return idx
+}

--- a/Sources/DocEngine/StoreAdapters/FileStore.swift
+++ b/Sources/DocEngine/StoreAdapters/FileStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public final class FileStore: DocumentStore {
+    private let baseURL: URL
+
+    public init(directory: URL) {
+        self.baseURL = directory
+    }
+
+    public func load(id: String) async throws -> (text: String, revision: String) {
+        let url = baseURL.appendingPathComponent(id)
+        guard let data = try? Data(contentsOf: url) else { throw DocError.notFound }
+        let text = String(decoding: data, as: UTF8.self)
+        let revision = try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+        let revString = revision.map { String($0.timeIntervalSince1970) } ?? "0"
+        return (text, revString)
+    }
+
+    public func save(id: String, newText: String, expectedRevision: String, diffProducer: @Sendable (String, String) -> String) async throws -> String {
+        let url = baseURL.appendingPathComponent(id)
+        var currentRevision = "0"
+        if FileManager.default.fileExists(atPath: url.path) {
+            let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+            if let date = attrs[.modificationDate] as? Date {
+                currentRevision = String(date.timeIntervalSince1970)
+            }
+            if currentRevision != expectedRevision {
+                throw DocError.revisionConflict(current: currentRevision)
+            }
+        }
+        try newText.write(to: url, atomically: true, encoding: .utf8)
+        let revString = String(Date().timeIntervalSince1970)
+        return revString
+    }
+}

--- a/Sources/DocEngine/StoreAdapters/InMemoryStore.swift
+++ b/Sources/DocEngine/StoreAdapters/InMemoryStore.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public actor InMemoryStore: DocumentStore {
+    private struct Entry { var text: String; var revision: String }
+    private var storage: [String: Entry] = [:]
+
+    public init() {}
+
+    public func load(id: String) async throws -> (text: String, revision: String) {
+        guard let entry = storage[id] else { throw DocError.notFound }
+        return (entry.text, entry.revision)
+    }
+
+    public func save(id: String, newText: String, expectedRevision: String, diffProducer: @Sendable (String, String) -> String) async throws -> String {
+        if let entry = storage[id] {
+            if entry.revision != expectedRevision {
+                throw DocError.revisionConflict(current: entry.revision)
+            }
+        }
+        let revision = UUID().uuidString
+        storage[id] = Entry(text: newText, revision: revision)
+        return revision
+    }
+}

--- a/Tests/DocEngineTests/ASTIndexTests.swift
+++ b/Tests/DocEngineTests/ASTIndexTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import DocEngine
+import Markdown
+import Foundation
+
+struct ASTIndexTests {
+    @Test func buildsMap() async throws {
+        let text = "# Head One\n\n## Sub Head\n\n```swift\ncode\n```"
+        let document = Document(parsing: text)
+        let index = buildIndex(document: document, text: text)
+        #expect(index.map[["head-one"]] != nil)
+        #expect(index.map[["head-one","sub-head"]] != nil)
+        #expect(index.map[["head-one","sub-head","code-swift"]] != nil)
+    }
+
+    @Test func slugNormalisation() async throws {
+        let text = "#   S p a c e s  ###\n"
+        let doc = Document(parsing: text)
+        let index = buildIndex(document: doc, text: text)
+        #expect(index.map[["s-p-a-c-e-s"]] != nil)
+    }
+
+    @Test func nestedPaths() async throws {
+        guard let url = Bundle.module.url(forResource: "nested", withExtension: "md", subdirectory: "Fixtures") else { throw DocError.notFound }
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let doc = Document(parsing: text)
+        let idx = buildIndex(document: doc, text: text, options: [.paragraphs])
+        #expect(idx.map[["level1","level2","level3","para"]] != nil)
+    }
+}
+
+
+

--- a/Tests/DocEngineTests/DiffTests.swift
+++ b/Tests/DocEngineTests/DiffTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import DocEngine
+
+struct DiffTests {
+    @Test func simpleDiff() async throws {
+        let old = "a\nb\n"
+        let new = "a\nc\n"
+        let patch = SimpleDiff.unified(old: old, new: new)
+        #expect(patch.contains("-b"))
+        #expect(patch.contains("+c"))
+    }
+
+    @Test func multiLineDiff() async throws {
+        let old = "one\ntwo\nthree"
+        let new = "one\n2\nthree\nfour"
+        let patch = SimpleDiff.unified(old: old, new: new)
+        #expect(patch.contains("-two"))
+        #expect(patch.contains("+2"))
+        #expect(patch.contains("+four"))
+    }
+}
+
+

--- a/Tests/DocEngineTests/DocEngineTests.swift
+++ b/Tests/DocEngineTests/DocEngineTests.swift
@@ -1,0 +1,71 @@
+import Testing
+@testable import DocEngine
+
+struct DocEngineTests {
+    @Test func readSlice() async throws {
+        let store = InMemoryStore()
+        _ = try await store.save(id: "doc", newText: "# Title\n\nHello", expectedRevision: "", diffProducer: {_,_ in ""})
+        let engine = DocEngine(store: store)
+        let selector = Selector(path: ["title"])
+        let slice = try await engine.read("doc", selector: selector)
+        #expect(slice.text.contains("Title"))
+    }
+
+    @Test func applyReplace() async throws {
+        let store = InMemoryStore()
+        let rev = try await store.save(id: "doc", newText: "Hello", expectedRevision: "", diffProducer: {_,_ in ""})
+        let engine = DocEngine(store: store)
+        let edit = ASTEdit(op: .replace, selector: Selector(path: ["x"], range: 0..<5), text: "Hi")
+        let env = try await engine.apply(edit: edit, to: "doc", expectedRevision: rev)
+        #expect(env.patch.contains("-Hello"))
+        #expect(env.patch.contains("+Hi"))
+    }
+
+    @Test func customDiffProducer() async throws {
+        actor MockStore: DocumentStore {
+            var savedDiff: String?
+            var text: String = ""
+
+            func load(id: String) async throws -> (text: String, revision: String) {
+                (text, "0")
+            }
+
+            func save(id: String, newText: String, expectedRevision: String, diffProducer: @Sendable (String, String) -> String) async throws -> String {
+                savedDiff = diffProducer(text, newText)
+                text = newText
+                return "1"
+            }
+        }
+        let store = MockStore()
+        let engine = DocEngine(store: store)
+        let _ = try await engine.apply(edit: ASTEdit(op: .insert, selector: Selector(path: ["*"], range: 0..<0), text: "X"), to: "doc", expectedRevision: "0")
+        let diff = await store.savedDiff
+        #expect(diff?.contains("+X") == true)
+    }
+
+    @Test func revisionConflict() async throws {
+        let store = InMemoryStore()
+        let rev1 = try await store.save(id: "doc", newText: "Hello", expectedRevision: "", diffProducer: {_,_ in ""})
+        _ = try await store.save(id: "doc", newText: "World", expectedRevision: rev1, diffProducer: {_,_ in ""})
+        let engine = DocEngine(store: store)
+        let edit = ASTEdit(op: .replace, selector: Selector(path: ["*"], range: 0..<5), text: "Hi")
+        do {
+            _ = try await engine.apply(edit: edit, to: "doc", expectedRevision: rev1)
+            #expect(false)
+        } catch DocError.revisionConflict {
+            #expect(true)
+        }
+    }
+
+    @Test func unicodeRange() async throws {
+        let store = InMemoryStore()
+        _ = try await store.save(id: "u", newText: "😀 Hello", expectedRevision: "", diffProducer: {_,_ in ""})
+        let engine = DocEngine(store: store)
+        let slice = try await engine.read("u", selector: Selector(path: ["none"], range: 0..<4))
+        #expect(slice.text == "😀")
+    }
+}
+
+
+
+

--- a/Tests/DocEngineTests/Fixtures/advanced.md
+++ b/Tests/DocEngineTests/Fixtures/advanced.md
@@ -1,0 +1,20 @@
+# Title
+
+Intro text.
+
+## Section A
+
+Content A.
+
+```swift
+print("hello")
+```
+
+### Subsection A1
+
+More text.
+
+## Section B
+
+Emoji: 😀
+

--- a/Tests/DocEngineTests/Fixtures/nested.md
+++ b/Tests/DocEngineTests/Fixtures/nested.md
@@ -1,0 +1,9 @@
+# Level1
+
+Some text
+
+## Level2
+
+### Level3
+
+Paragraph text.

--- a/Tests/DocEngineTests/Fixtures/sample.md
+++ b/Tests/DocEngineTests/Fixtures/sample.md
@@ -1,0 +1,3 @@
+# Title
+
+Hello world

--- a/Tests/DocEngineTests/IntegrationTests.swift
+++ b/Tests/DocEngineTests/IntegrationTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import DocEngine
+
+struct IntegrationTests {
+    @Test func replaceSection() async throws {
+        guard let url = Bundle.module.url(forResource: "advanced", withExtension: "md", subdirectory: "Fixtures") else {
+            throw DocError.notFound
+        }
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let store = InMemoryStore()
+        let rev = try await store.save(id: "doc", newText: text, expectedRevision: "", diffProducer: {_,_ in ""})
+        let engine = DocEngine(store: store)
+
+        let selector = Selector(path: ["title","section-a"])
+        let edit = ASTEdit(op: .replace, selector: selector, text: "Changed")
+        let envelope = try await engine.apply(edit: edit, to: "doc", expectedRevision: rev)
+        #expect(envelope.changes.first?.newText == "Changed")
+    }
+
+    @Test func mockStoreInteractions() async throws {
+        actor MockStore: DocumentStore {
+            var loadCalls = 0
+            var saveCalls = 0
+            var text: String = "initial"
+
+            func load(id: String) async throws -> (text: String, revision: String) {
+                loadCalls += 1
+                return (text, "r1")
+            }
+
+            func save(id: String, newText: String, expectedRevision: String, diffProducer: @Sendable (String, String) -> String) async throws -> String {
+                saveCalls += 1
+                text = newText
+                _ = diffProducer("", newText)
+                return "r2"
+            }
+        }
+
+        let store = MockStore()
+        let engine = DocEngine(store: store)
+        _ = try await engine.apply(edit: ASTEdit(op: .replace, selector: Selector(path: ["*"], range: 0..<0), text: "new"), to: "doc", expectedRevision: "r1")
+        let loads = await store.loadCalls
+        let saves = await store.saveCalls
+        #expect(loads > 0)
+        #expect(saves == 1)
+    }
+}
+
+
+


### PR DESCRIPTION
## Summary
- document diff strategy
- expose index options in `DocEngine` and include detailed API docs
- ensure unique slugs and maintain heading stack in `ASTIndex`
- support optional paragraph indexing and add nested fixture
- adjust tests for new paths

## Testing
- `swift test -c debug`

------
https://chatgpt.com/codex/tasks/task_e_684b9b7e4a548331bc45b8c1870e2c30